### PR TITLE
DomainEvent.getEventTime() 메서드 이름을 getOccurrenceTime으로 변경합니다.

### DIFF
--- a/src/main/java/io/loom/core/event/DomainEvent.java
+++ b/src/main/java/io/loom/core/event/DomainEvent.java
@@ -12,5 +12,5 @@ public interface DomainEvent extends Serializable {
 
     long getVersion();
 
-    ZonedDateTime getEventTime();
+    ZonedDateTime getOccurrenceTime();
 }

--- a/src/test/java/io/loom/core/fixtures/IssueEvent.java
+++ b/src/test/java/io/loom/core/fixtures/IssueEvent.java
@@ -36,7 +36,7 @@ public interface IssueEvent extends DomainEvent {
         }
 
         @Override
-        public ZonedDateTime getEventTime() {
+        public ZonedDateTime getOccurrenceTime() {
             return eventTime;
         }
 
@@ -73,7 +73,7 @@ public interface IssueEvent extends DomainEvent {
         }
 
         @Override
-        public ZonedDateTime getEventTime() {
+        public ZonedDateTime getOccurrenceTime() {
             return eventTime;
         }
 
@@ -106,7 +106,7 @@ public interface IssueEvent extends DomainEvent {
         }
 
         @Override
-        public ZonedDateTime getEventTime() {
+        public ZonedDateTime getOccurrenceTime() {
             return eventTime;
         }
 


### PR DESCRIPTION
이벤트 발생 시각과 관련된 표현으로 `time of occurrence`이 있는데 Java 코드에서는 전치사를 빼고 `OccurrenceTime` 이라고 많이 쓰네요. 설명을 보면 `occurrence time of an event`를 줄여 쓰는 것으로 보입니다. 중요도가 아주 높진 않지만 설명력이 좀 더 높고 일반적으로 사용되는 표현이라고 생각되어 PR 작성합니다.