### PR TITLE
checkstyle 위배할 경우 CI 빌드를 실패하도록 구성합니다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,3 +17,21 @@ dependencies {
 checkstyle {
     toolVersion = '7.7'
 }
+
+/**
+ * ignoreFailures = false 설정만으로 checkstyle 위배 시 빌드가 실패해야 하지만
+ * 다음과 같은 버그가 있습니다.
+ * https://github.com/gradle/gradle/issues/881
+ *
+ * 이 구성은 버그가 해결될 때 까지 사용되는 임시방편입니다.
+ * */
+tasks.withType(Checkstyle).each { checkstyleTask ->
+    checkstyleTask.doLast {
+        reports.all { report ->
+            def outputFile = report.destination
+            if (outputFile.exists() && outputFile.text.contains("<error ")) {
+                throw new GradleException("There were checkstyle warnings! For more info check $outputFile")
+            }
+        }
+    }
+}


### PR DESCRIPTION
- 아래링크는 이 구성을 통해 checkstyle 위배 시 실패한 빌드 결과를 보여줍니다.
https://travis-ci.org/loom/loom-core/builds/229577579?utm_source=github_status&utm_medium=notification

- 로컬에서도 checkstyle 위배 시 `gradle check` 가 실패합니다.

-  스택오버플로우에서 참고한 내용입니다.(컷밋 메세지 내용 참고) 구성한 방법이 적절한지 리뷰 부탁드려요. 

- 저는 checkstyle을 사용한 이상 위배 시 빌드 실패를 하는게 좋다는 의견입니다. 혹시 이견있으시면 말씀주세요.