### PR TITLE
constructor_has_guard_clause_for_null_id 테스트 케이스 보강

### DIFF
--- a/src/test/java/io/loom/core/aggregate/AbstractAggregateRootSpecs.java
+++ b/src/test/java/io/loom/core/aggregate/AbstractAggregateRootSpecs.java
@@ -29,7 +29,7 @@ public class AbstractAggregateRootSpecs {
         Assert.assertNotNull(expected);
         Assert.assertTrue(
                 "The error message should contain the name of the parameter 'id'.",
-                expected.getMessage().contains("id"));
+                expected.getMessage().contains("'id'"));
     }
 
     @Test


### PR DESCRIPTION
`AbstractAggregateRootSpecs.constructor_has_guard_clause_for_null_id` 테스트 케이스의 검증 코드는 오류 메시지가 `id` 매개변수 이름을 포함하는지 검사합니다. 이때 매개변수 이름이 누락되어도 `id` 문자열이 다른 단어에 섞이면 테스트가 성공할 가능성을 가집니다. 이 문제를 수정합니다.