### PR TITLE
AbstractAggregateRoot 구현 메소드에 final 을 붙입니다.

### DIFF
--- a/src/main/java/io/loom/core/aggregate/AbstractAggregateRoot.java
+++ b/src/main/java/io/loom/core/aggregate/AbstractAggregateRoot.java
@@ -17,7 +17,7 @@ public abstract class AbstractAggregateRoot implements AggregateRoot {
 
     @Override
     public final UUID getId() {
-        return id;
+        return this.id;
     }
 
     @Override

--- a/src/main/java/io/loom/core/aggregate/AbstractAggregateRoot.java
+++ b/src/main/java/io/loom/core/aggregate/AbstractAggregateRoot.java
@@ -16,17 +16,17 @@ public abstract class AbstractAggregateRoot implements AggregateRoot {
     }
 
     @Override
-    public UUID getId() {
+    public final UUID getId() {
         return id;
     }
 
     @Override
-    public long getVersion() {
+    public final long getVersion() {
         return 0;
     }
 
     @Override
-    public Iterable<DomainEvent> pollAllPendingEvents() {
+    public final Iterable<DomainEvent> pollAllPendingEvents() {
         return null;
     }
 }


### PR DESCRIPTION
getId(), getVersion(), pollAllPendingEvents() 모두 하위 구현 클래스에서 Override 할 필요가 없을거 같습니다.
필요성이 생기기 전까지 final 을 붙입니다.