### PR TITLE
constructor_sets_header_properties_correctly 테스트 케이스 검증력을 높입니다.

### DIFF
--- a/src/test/java/io/loom/core/event/AbstractDomainEventSpecs.java
+++ b/src/test/java/io/loom/core/event/AbstractDomainEventSpecs.java
@@ -1,6 +1,7 @@
 package io.loom.core.event;
 
 import java.time.ZonedDateTime;
+import java.util.Random;
 import java.util.UUID;
 
 import org.junit.Assert;
@@ -78,8 +79,9 @@ public class AbstractDomainEventSpecs {
     public void constructor_sets_header_properties_correctly() {
         // Arrange
         UUID aggregateId = UUID.randomUUID();
-        long version = 1;
-        ZonedDateTime occurrenceTime = ZonedDateTime.now();
+        Random random = new Random();
+        long version = random.nextInt(Integer.MAX_VALUE) + 1L;
+        ZonedDateTime occurrenceTime = ZonedDateTime.now().plusNanos(random.nextInt());
 
         // Act
         IssueCreatedForTesting sut = new IssueCreatedForTesting(


### PR DESCRIPTION
`AbstractDomainEventSpecs.constructor_sets_header_properties_correctly` 테스트 케이스는 버전 속성이 잘 설정되는지 검증하기 위해 기대값을 `1`로 설정합니다.

```java
long version = 1;
...
Assert.assertEquals(version, sut.getVersion());
```

이 때 `AbstractDomainEvent` 클래스 생성자가 `version` 필드를 다음과 같이 초기화해도 테스트 케이스는 성공합니다.

```java
protected AbstractDomainEvent(UUID aggregateId, long version, ZonedDateTime occurrenceTime) {
    ...
    this.aggregateId = aggregateId;
    this.version = 1; // The parameter 'version' is ignored.
    this.occurrenceTime = occurrenceTime;
}

public final long getVersion() {
    return this.version;
}
```

이것은 기대된 동작이 아닙니다. 이런 오류를 검증할 수 있도록 테스트 케이스의 검증력을 높입니다.