### PR TITLE
DomainEvent 의 Header 정보를 후처리 셋팅하는 LazyInitializedDomainEvent 를 추가합니다.

### DIFF
--- a/src/main/java/io/loom/core/aggregate/AbstractAggregateRoot.java
+++ b/src/main/java/io/loom/core/aggregate/AbstractAggregateRoot.java
@@ -4,8 +4,9 @@ import io.loom.core.event.DomainEvent;
 
 import java.util.UUID;
 
-public abstract class AbstractAggregateRoot implements AggregateRoot {
+public abstract class AbstractAggregateRoot implements AggregateRoot, VersionedAggregate {
     private final UUID id;
+    private long version;
 
     protected AbstractAggregateRoot(UUID id) {
         if (id == null) {
@@ -13,6 +14,7 @@ public abstract class AbstractAggregateRoot implements AggregateRoot {
         }
 
         this.id = id;
+        this.version = 0;
     }
 
     @Override
@@ -22,7 +24,7 @@ public abstract class AbstractAggregateRoot implements AggregateRoot {
 
     @Override
     public final long getVersion() {
-        return 0;
+        return version;
     }
 
     @Override

--- a/src/main/java/io/loom/core/aggregate/AbstractAggregateRoot.java
+++ b/src/main/java/io/loom/core/aggregate/AbstractAggregateRoot.java
@@ -17,6 +17,14 @@ public abstract class AbstractAggregateRoot implements AggregateRoot, VersionedA
         this.version = 0;
     }
 
+    protected final void raise(DomainEvent domainEvent) {
+        if (domainEvent == null) {
+            throw new IllegalArgumentException("The parameter 'domainEvent' cannot be null.");
+        }
+
+        // apply and pending
+    }
+
     @Override
     public final UUID getId() {
         return this.id;

--- a/src/main/java/io/loom/core/aggregate/AbstractAggregateRoot.java
+++ b/src/main/java/io/loom/core/aggregate/AbstractAggregateRoot.java
@@ -1,6 +1,7 @@
 package io.loom.core.aggregate;
 
 import io.loom.core.event.DomainEvent;
+import io.loom.core.event.LazyInitializedDomainEvent;
 
 import java.util.UUID;
 
@@ -22,7 +23,15 @@ public abstract class AbstractAggregateRoot implements AggregateRoot, VersionedA
             throw new IllegalArgumentException("The parameter 'domainEvent' cannot be null.");
         }
 
-        // apply and pending
+        if (domainEvent instanceof LazyInitializedDomainEvent) {
+            LazyInitializedDomainEvent lazyEvent = (LazyInitializedDomainEvent) domainEvent;
+            if (!lazyEvent.isInitialized()) {
+                lazyEvent.afterHeaderPropertiesSets(this);
+            }
+        }
+
+        // TODO: guard clause domain event header properties sets
+        // TODO: apply and pending
     }
 
     @Override

--- a/src/main/java/io/loom/core/aggregate/AggregateRoot.java
+++ b/src/main/java/io/loom/core/aggregate/AggregateRoot.java
@@ -10,7 +10,5 @@ import java.util.UUID;
 public interface AggregateRoot extends Serializable {
     UUID getId();
 
-    long getVersion();
-
     Iterable<DomainEvent> pollAllPendingEvents();
 }

--- a/src/main/java/io/loom/core/aggregate/VersionedAggregate.java
+++ b/src/main/java/io/loom/core/aggregate/VersionedAggregate.java
@@ -1,0 +1,9 @@
+package io.loom.core.aggregate;
+
+import java.util.UUID;
+
+public interface VersionedAggregate {
+    UUID getId();
+
+    long getVersion();
+}

--- a/src/main/java/io/loom/core/event/AbstractDomainEvent.java
+++ b/src/main/java/io/loom/core/event/AbstractDomainEvent.java
@@ -1,27 +1,46 @@
 package io.loom.core.event;
 
+import io.loom.core.aggregate.VersionedAggregate;
+
 import java.time.ZonedDateTime;
 import java.util.UUID;
 
-public abstract class AbstractDomainEvent implements DomainEvent {
-    private final UUID aggregateId;
-    private final long version;
-    private final ZonedDateTime occurrenceTime;
+public abstract class AbstractDomainEvent implements LazyInitializedDomainEvent {
+    private UUID aggregateId;
+    private long version;
+    private ZonedDateTime occurrenceTime;
+
+    protected AbstractDomainEvent() {
+    }
 
     protected AbstractDomainEvent(UUID aggregateId, long version, ZonedDateTime occurrenceTime) {
-        if (aggregateId == null) {
-            throw new IllegalArgumentException("The parameter 'aggregateId' cannot be null.");
+        this.checkHeaderPropertiesSet(aggregateId, version, occurrenceTime);
+        this.aggregateId = aggregateId;
+        this.version = version;
+        this.occurrenceTime = occurrenceTime;
+    }
+
+    @Override
+    public final void afterHeaderPropertiesSets(VersionedAggregate versionedAggregate) {
+        if (this.isInitialized()) {
+            throw new IllegalStateException("DomainEvent is already initialized.");
         }
-        if (version < 1) {
-            throw new IllegalArgumentException("The parameter 'version' must be greater than 0.");
-        }
-        if (occurrenceTime == null) {
-            throw new IllegalArgumentException("The parameter 'occurrenceTime' cannot be null.");
-        }
+
+        UUID aggregateId = versionedAggregate.getId();
+        long version = versionedAggregate.getVersion() + 1;
+        ZonedDateTime occurrenceTime = ZonedDateTime.now();
+        this.checkHeaderPropertiesSet(aggregateId, version, occurrenceTime);
 
         this.aggregateId = aggregateId;
         this.version = version;
         this.occurrenceTime = occurrenceTime;
+    }
+
+    @Override
+    public final boolean isInitialized() {
+        return this.aggregateId != null
+                && this.version > 0
+                && this.occurrenceTime != null;
     }
 
     @Override
@@ -37,5 +56,18 @@ public abstract class AbstractDomainEvent implements DomainEvent {
     @Override
     public final ZonedDateTime getOccurrenceTime() {
         return this.occurrenceTime;
+    }
+
+    private void checkHeaderPropertiesSet(
+            UUID aggregateId, long version, ZonedDateTime occurrenceTime) {
+        if (aggregateId == null) {
+            throw new IllegalArgumentException("The parameter 'aggregateId' cannot be null.");
+        }
+        if (version < 1) {
+            throw new IllegalArgumentException("The parameter 'version' must be greater than 0.");
+        }
+        if (occurrenceTime == null) {
+            throw new IllegalArgumentException("The parameter 'occurrenceTime' cannot be null.");
+        }
     }
 }

--- a/src/main/java/io/loom/core/event/LazyInitializedDomainEvent.java
+++ b/src/main/java/io/loom/core/event/LazyInitializedDomainEvent.java
@@ -1,0 +1,9 @@
+package io.loom.core.event;
+
+import io.loom.core.aggregate.VersionedAggregate;
+
+public interface LazyInitializedDomainEvent extends DomainEvent {
+    boolean isInitialized();
+
+    void afterHeaderPropertiesSets(VersionedAggregate versionedAggregate);
+}

--- a/src/test/java/io/loom/core/aggregate/AbstractAggregateRootSpecs.java
+++ b/src/test/java/io/loom/core/aggregate/AbstractAggregateRootSpecs.java
@@ -54,4 +54,24 @@ public class AbstractAggregateRootSpecs {
         // Assert
         Assert.assertEquals(0, sut.getVersion());
     }
+
+    @Test
+    public void raise_has_guard_clause_for_null_domainEvent() {
+        // Arrange
+        IssueForTesting issue = new IssueForTesting(UUID.randomUUID());
+
+        // Act
+        IllegalArgumentException expected = null;
+        try {
+            issue.raise(null);
+        } catch (IllegalArgumentException e) {
+            expected = e;
+        }
+
+        // Assert
+        Assert.assertNotNull(expected);
+        Assert.assertTrue(
+                "The error message should contain the name of the parameter 'domainEvent'.",
+                expected.getMessage().contains("'domainEvent'"));
+    }
 }

--- a/src/test/java/io/loom/core/aggregate/AbstractAggregateRootSpecs.java
+++ b/src/test/java/io/loom/core/aggregate/AbstractAggregateRootSpecs.java
@@ -1,5 +1,10 @@
 package io.loom.core.aggregate;
 
+import io.loom.core.event.DomainEvent;
+import io.loom.core.event.LazyInitializedDomainEvent;
+
+import java.time.ZonedDateTime;
+import java.util.Random;
 import java.util.UUID;
 
 import org.junit.Assert;
@@ -9,6 +14,67 @@ public class AbstractAggregateRootSpecs {
     public class IssueForTesting extends AbstractAggregateRoot {
         public IssueForTesting(UUID id) {
             super(id);
+        }
+    }
+
+    public class IssueEventForTesting implements DomainEvent {
+        private UUID aggregateId;
+        private long version;
+        private ZonedDateTime occurrenceTime;
+
+        public IssueEventForTesting(UUID aggregateId, long version, ZonedDateTime occurrenceTime) {
+            this.aggregateId = aggregateId;
+            this.version = version;
+            this.occurrenceTime = occurrenceTime;
+        }
+
+        @Override
+        public UUID getAggregateId() {
+            return this.aggregateId;
+        }
+
+        @Override
+        public long getVersion() {
+            return this.version;
+        }
+
+        @Override
+        public ZonedDateTime getOccurrenceTime() {
+            return this.occurrenceTime;
+        }
+    }
+
+    public class LazyEventForTesting implements LazyInitializedDomainEvent {
+        public boolean initialized;
+        private ZonedDateTime occurrenceTime;
+
+        public LazyEventForTesting() {
+        }
+
+        @Override
+        public boolean isInitialized() {
+            return this.initialized;
+        }
+
+        @Override
+        public void afterHeaderPropertiesSets(VersionedAggregate versionedAggregate) {
+            this.initialized = true;
+            this.occurrenceTime = ZonedDateTime.now();
+        }
+
+        @Override
+        public UUID getAggregateId() {
+            return null;
+        }
+
+        @Override
+        public long getVersion() {
+            return 0;
+        }
+
+        @Override
+        public ZonedDateTime getOccurrenceTime() {
+            return occurrenceTime;
         }
     }
 
@@ -73,5 +139,59 @@ public class AbstractAggregateRootSpecs {
         Assert.assertTrue(
                 "The error message should contain the name of the parameter 'domainEvent'.",
                 expected.getMessage().contains("'domainEvent'"));
+    }
+
+    @Test
+    public void raise_lazyEvent_afterHeaderPropertiesSets_correctly() {
+        // Arrange
+        IssueForTesting issue = new IssueForTesting(UUID.randomUUID());
+        LazyEventForTesting unInitializedLazyEvent = new LazyEventForTesting();
+
+        // Act
+        issue.raise(unInitializedLazyEvent);
+
+        // Assert
+        Assert.assertTrue(unInitializedLazyEvent.isInitialized());
+        Assert.assertNotNull(unInitializedLazyEvent.getOccurrenceTime());
+    }
+
+    @Test
+    public void raise_initialized_lazyEvent_do_not_invoke_afterHeaderPropertiesSets() {
+        // Arrange
+        IssueForTesting issue = new IssueForTesting(UUID.randomUUID());
+        LazyEventForTesting initializedLazyEvent = new LazyEventForTesting();
+        initializedLazyEvent.initialized = true;
+
+
+        // Act
+        issue.raise(initializedLazyEvent);
+
+        // Assert
+        Assert.assertTrue(initializedLazyEvent.isInitialized());
+        Assert.assertNull(initializedLazyEvent.getOccurrenceTime());
+    }
+
+    // LazyInitializedDomainEvent 를 구현하지 않은 event 에는 변경이 발생하지 않는 테스트 입니다.
+    // raise() 에서 domainEvent 의 header properties sets 를 검사하는 guard 로직이 추가되면
+    // 이 테스트는 실패하고 테스트를 조건을 수정해야 합니다.
+    @Test
+    public void raise_pure_domain_event_do_not_change_header_properties_set() {
+        // Arrange
+        IssueForTesting issue = new IssueForTesting(UUID.randomUUID());
+
+        UUID aggregateId = UUID.randomUUID();
+        Random random = new Random();
+        long version = random.nextInt(Integer.MAX_VALUE) + 1L;
+        ZonedDateTime occurrenceTime = ZonedDateTime.now().plusNanos(random.nextInt());
+        IssueEventForTesting pureDomainEvent =
+                new IssueEventForTesting(aggregateId, version, occurrenceTime);
+
+        // Act
+        issue.raise(pureDomainEvent);
+
+        // Assert
+        Assert.assertEquals(aggregateId, pureDomainEvent.getAggregateId());
+        Assert.assertEquals(version, pureDomainEvent.getVersion());
+        Assert.assertEquals(occurrenceTime, pureDomainEvent.getOccurrenceTime());
     }
 }

--- a/src/test/java/io/loom/core/aggregate/AbstractAggregateRootSpecs.java
+++ b/src/test/java/io/loom/core/aggregate/AbstractAggregateRootSpecs.java
@@ -22,6 +22,13 @@ public class AbstractAggregateRootSpecs {
         private long version;
         private ZonedDateTime occurrenceTime;
 
+        /**
+         * Instantiates a new Issue event for testing.
+         *
+         * @param aggregateId    the aggregate id
+         * @param version        the version
+         * @param occurrenceTime the occurrence time
+         */
         public IssueEventForTesting(UUID aggregateId, long version, ZonedDateTime occurrenceTime) {
             this.aggregateId = aggregateId;
             this.version = version;

--- a/src/test/java/io/loom/core/event/AbstractDomainEventSpecs.java
+++ b/src/test/java/io/loom/core/event/AbstractDomainEventSpecs.java
@@ -1,10 +1,11 @@
 package io.loom.core.event;
 
+import io.loom.core.aggregate.VersionedAggregate;
+
 import java.time.ZonedDateTime;
 import java.util.Random;
 import java.util.UUID;
 
-import io.loom.core.aggregate.VersionedAggregate;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/src/test/java/io/loom/core/event/AbstractDomainEventSpecs.java
+++ b/src/test/java/io/loom/core/event/AbstractDomainEventSpecs.java
@@ -4,14 +4,38 @@ import java.time.ZonedDateTime;
 import java.util.Random;
 import java.util.UUID;
 
+import io.loom.core.aggregate.VersionedAggregate;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class AbstractDomainEventSpecs {
     public class IssueCreatedForTesting extends AbstractDomainEvent {
+        public IssueCreatedForTesting() {
+        }
+
         public IssueCreatedForTesting(
                 UUID aggregateId, long version, ZonedDateTime occurrenceTime) {
             super(aggregateId, version, occurrenceTime);
+        }
+    }
+
+    public class VersionedIssueForTesting implements VersionedAggregate {
+        private final UUID id;
+        private long version;
+
+        public VersionedIssueForTesting(UUID id, long version) {
+            this.id = id;
+            this.version = version;
+        }
+
+        @Override
+        public UUID getId() {
+            return this.id;
+        }
+
+        @Override
+        public long getVersion() {
+            return this.version;
         }
     }
 
@@ -91,5 +115,141 @@ public class AbstractDomainEventSpecs {
         Assert.assertEquals(aggregateId, sut.getAggregateId());
         Assert.assertEquals(version, sut.getVersion());
         Assert.assertEquals(occurrenceTime, sut.getOccurrenceTime());
+    }
+
+    @Test
+    public void isInitialized_by_constructor_true() {
+        // Arrange
+        IssueCreatedForTesting domainEvent
+                = new IssueCreatedForTesting(UUID.randomUUID(), 1, ZonedDateTime.now());
+
+        // Act
+        boolean sut = domainEvent.isInitialized();
+
+        // Assert
+        Assert.assertTrue(sut);
+    }
+
+    @Test
+    public void isInitialized_by_no_args_constructor_false() {
+        // Arrange
+        IssueCreatedForTesting domainEvent = new IssueCreatedForTesting();
+
+        // Act
+        boolean sut = domainEvent.isInitialized();
+
+        // Assert
+        Assert.assertFalse(sut);
+    }
+
+    @Test
+    public void isInitialized_by_afterHeaderPropertiesSets_true() {
+        // Arrange
+        VersionedAggregate versionedAggregate
+                = new VersionedIssueForTesting(UUID.randomUUID(), 0);
+        IssueCreatedForTesting domainEvent = new IssueCreatedForTesting();
+        domainEvent.afterHeaderPropertiesSets(versionedAggregate);
+
+        // Act
+        boolean sut = domainEvent.isInitialized();
+
+        // Assert
+        Assert.assertTrue(sut);
+    }
+
+    @Test
+    public void afterHeaderPropertiesSets_correctly() {
+        // Arrange
+        Random random = new Random();
+        long version = random.nextInt(Integer.MAX_VALUE) + 1L;
+        VersionedAggregate versionedAggregate =
+                new VersionedIssueForTesting(UUID.randomUUID(), version);
+        IssueCreatedForTesting domainEvent = new IssueCreatedForTesting();
+
+        // Act
+        domainEvent.afterHeaderPropertiesSets(versionedAggregate);
+
+        // Assert
+        Assert.assertNotNull(domainEvent.getAggregateId());
+        Assert.assertEquals(domainEvent.getAggregateId(), versionedAggregate.getId());
+        Assert.assertTrue(domainEvent.getVersion() > 0);
+        Assert.assertTrue(domainEvent.getVersion() == versionedAggregate.getVersion() + 1);
+        Assert.assertNotNull(domainEvent.getOccurrenceTime());
+        ZonedDateTime after = ZonedDateTime.now();
+        Assert.assertTrue(
+                domainEvent.getOccurrenceTime().toEpochSecond()
+                        <= after.toEpochSecond());
+        Assert.assertTrue(
+                domainEvent.getOccurrenceTime().toEpochSecond()
+                        >= after.minusSeconds(1).toEpochSecond());
+    }
+
+    @Test
+    public void afterHeaderPropertiesSets_for_already_initialized() {
+        // Arrange
+        VersionedAggregate versionedAggregate =
+                new VersionedIssueForTesting(UUID.randomUUID(), 0);
+        IssueCreatedForTesting domainEvent
+                = new IssueCreatedForTesting(UUID.randomUUID(), 1, ZonedDateTime.now());
+
+        // Act
+        IllegalStateException expected = null;
+        try {
+            domainEvent.afterHeaderPropertiesSets(versionedAggregate);
+        } catch (IllegalStateException e) {
+            expected = e;
+        }
+
+        // Assert
+        Assert.assertNotNull(expected);
+        Assert.assertTrue(
+                "The error message should contain the state of the domain event.",
+                expected.getMessage().contains("already initialized"));
+    }
+
+    @Test
+    public void afterHeaderPropertiesSets_has_guard_clause_for_null_aggregateId() {
+        // Arrange
+        UUID aggregateId = null;
+        VersionedAggregate versionedAggregate =
+                new VersionedIssueForTesting(aggregateId, 0);
+        IssueCreatedForTesting domainEvent = new IssueCreatedForTesting();
+
+        // Act
+        IllegalArgumentException expected = null;
+        try {
+            domainEvent.afterHeaderPropertiesSets(versionedAggregate);
+        } catch (IllegalArgumentException e) {
+            expected = e;
+        }
+
+        // Assert
+        Assert.assertNotNull(expected);
+        Assert.assertTrue(
+                "The error message should contain the name of the parameter 'aggregateId'.",
+                expected.getMessage().contains("'aggregateId'"));
+    }
+
+    @Test
+    public void afterHeaderPropertiesSets_has_guard_clause_for_minimum_value_of_version() {
+        // Arrange
+        long version = -1;
+        VersionedAggregate versionedAggregate =
+                new VersionedIssueForTesting(UUID.randomUUID(), version);
+        IssueCreatedForTesting domainEvent = new IssueCreatedForTesting();
+
+        // Act
+        IllegalArgumentException expected = null;
+        try {
+            domainEvent.afterHeaderPropertiesSets(versionedAggregate);
+        } catch (IllegalArgumentException e) {
+            expected = e;
+        }
+
+        // Assert
+        Assert.assertNotNull(expected);
+        Assert.assertTrue(
+                "The error message should contain the name of the parameter 'version'.",
+                expected.getMessage().contains("'version'"));
     }
 }

--- a/src/test/java/io/loom/core/fixtures/Issue.java
+++ b/src/test/java/io/loom/core/fixtures/Issue.java
@@ -40,7 +40,6 @@ public class Issue implements AggregateRoot {
         return id;
     }
 
-    @Override
     public long getVersion() {
         return version;
     }


### PR DESCRIPTION
DomainEvent 의 headerPropertiesSets(aggregateId, version, occurrenceTime) 를 후처리로 셋팅할 수 있도록 합니다.

* `VersionedAggregate` 와  `LazyInitializedDomainEvent` 를 추가합니다.
* `AbstractAggregateRoot` 가 `VersionedAggregate` 를 구현합니다.
* `AbstractDomainEvent` 가 `LazyInitializedDomainEvent` 를 구현합니다.


설명은 여기에 작성했습니다.
https://github.com/loom/loom-core/issues/37#issuecomment-302602872
