### PR TITLE
Jackson 메시지 직렬화기를 추가합니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,9 @@ repositories {
 }
 
 dependencies {
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.8.8'
+    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.8.8'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.8.8'
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 

--- a/src/main/java/io/loom/core/messaging/JacksonMessageSerializer.java
+++ b/src/main/java/io/loom/core/messaging/JacksonMessageSerializer.java
@@ -4,13 +4,14 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder;
 
 import java.io.IOException;
 
 public class JacksonMessageSerializer implements MessageSerializer {
-    private class TypeResolverBuilder extends ObjectMapper.DefaultTypeResolverBuilder {
+    private class InternalTypeResolverBuilder extends ObjectMapper.DefaultTypeResolverBuilder {
 
-        TypeResolverBuilder() {
+        InternalTypeResolverBuilder() {
             super(ObjectMapper.DefaultTyping.NON_FINAL);
         }
 
@@ -23,7 +24,7 @@ public class JacksonMessageSerializer implements MessageSerializer {
     private final ObjectMapper mapper;
 
     {
-        com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder<?> typer = new TypeResolverBuilder();
+        TypeResolverBuilder<?> typer = new InternalTypeResolverBuilder();
         typer = typer.init(JsonTypeInfo.Id.CLASS, null);
         typer = typer.inclusion(JsonTypeInfo.As.PROPERTY);
         typer = typer.typeProperty("$type");
@@ -39,7 +40,8 @@ public class JacksonMessageSerializer implements MessageSerializer {
         try {
             return mapper.writeValueAsString(message);
         } catch (JsonProcessingException e) {
-            throw new RuntimeException("Could not serialize message. See the cause for details.", e);
+            String errorMessage = "Could not serialize message. See the cause for details.";
+            throw new RuntimeException(errorMessage, e);
         }
     }
 
@@ -52,7 +54,8 @@ public class JacksonMessageSerializer implements MessageSerializer {
         try {
             return mapper.readValue(value, Object.class);
         } catch (IOException e) {
-            throw new RuntimeException("Could not deserialize message. See the cause for details.", e);
+            String errorMessage = "Could not deserialize message. See the cause for details.";
+            throw new RuntimeException(errorMessage, e);
         }
     }
 }

--- a/src/main/java/io/loom/core/messaging/JacksonMessageSerializer.java
+++ b/src/main/java/io/loom/core/messaging/JacksonMessageSerializer.java
@@ -1,0 +1,58 @@
+package io.loom.core.messaging;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+public class JacksonMessageSerializer implements MessageSerializer {
+    private class TypeResolverBuilder extends ObjectMapper.DefaultTypeResolverBuilder {
+
+        TypeResolverBuilder() {
+            super(ObjectMapper.DefaultTyping.NON_FINAL);
+        }
+
+        @Override
+        public boolean useForType(JavaType t) {
+            return !t.isPrimitive();
+        }
+    }
+
+    private final ObjectMapper mapper;
+
+    {
+        com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder<?> typer = new TypeResolverBuilder();
+        typer = typer.init(JsonTypeInfo.Id.CLASS, null);
+        typer = typer.inclusion(JsonTypeInfo.As.PROPERTY);
+        typer = typer.typeProperty("$type");
+        mapper = new ObjectMapper().setDefaultTyping(typer);
+    }
+
+    @Override
+    public String serialize(Object message) {
+        if (message == null) {
+            throw new IllegalArgumentException("The parameter 'message' cannot be null.");
+        }
+
+        try {
+            return mapper.writeValueAsString(message);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Could not serialize message. See the cause for details.", e);
+        }
+    }
+
+    @Override
+    public Object deserialize(String value) {
+        if (value == null) {
+            throw new IllegalArgumentException("The parameter 'value' cannot be null.");
+        }
+
+        try {
+            return mapper.readValue(value, Object.class);
+        } catch (IOException e) {
+            throw new RuntimeException("Could not deserialize message. See the cause for details.", e);
+        }
+    }
+}

--- a/src/main/java/io/loom/core/messaging/MessageSerializer.java
+++ b/src/main/java/io/loom/core/messaging/MessageSerializer.java
@@ -1,0 +1,7 @@
+package io.loom.core.messaging;
+
+public interface MessageSerializer {
+    String serialize(Object message);
+
+    Object deserialize(String value);
+}

--- a/src/test/java/io/loom/core/messaging/EmptyObject.java
+++ b/src/test/java/io/loom/core/messaging/EmptyObject.java
@@ -1,0 +1,4 @@
+package io.loom.core.messaging;
+
+class EmptyObject {
+}

--- a/src/test/java/io/loom/core/messaging/FinalImmutableMessageWithJsonCreator.java
+++ b/src/test/java/io/loom/core/messaging/FinalImmutableMessageWithJsonCreator.java
@@ -1,0 +1,25 @@
+package io.loom.core.messaging;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+final class FinalImmutableMessageWithJsonCreator {
+    private final int intField;
+    private final String stringField;
+
+    @JsonCreator
+    FinalImmutableMessageWithJsonCreator(
+            @JsonProperty("intProperty") int intValue,
+            @JsonProperty("stringProperty") String stringValue) {
+        this.intField = intValue;
+        this.stringField = stringValue;
+    }
+
+    public int getIntProperty() {
+        return intField;
+    }
+
+    public String getStringProperty() {
+        return stringField;
+    }
+}

--- a/src/test/java/io/loom/core/messaging/ImmutableMessageWithJsonCreator.java
+++ b/src/test/java/io/loom/core/messaging/ImmutableMessageWithJsonCreator.java
@@ -1,0 +1,25 @@
+package io.loom.core.messaging;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+class ImmutableMessageWithJsonCreator {
+    private final int intField;
+    private final String stringField;
+
+    @JsonCreator
+    ImmutableMessageWithJsonCreator(
+            @JsonProperty("intProperty") int intValue,
+            @JsonProperty("stringProperty") String stringValue) {
+        this.intField = intValue;
+        this.stringField = stringValue;
+    }
+
+    public int getIntProperty() {
+        return intField;
+    }
+
+    public String getStringProperty() {
+        return stringField;
+    }
+}

--- a/src/test/java/io/loom/core/messaging/JacksonMessageSerializerSpecs.java
+++ b/src/test/java/io/loom/core/messaging/JacksonMessageSerializerSpecs.java
@@ -1,0 +1,185 @@
+package io.loom.core.messaging;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class JacksonMessageSerializerSpecs {
+    @Test
+    public void sut_implements_MessageSerializer() {
+        Assert.assertTrue(
+                "JacksonMessageSerializer does not implement MessageSerializer.",
+                implementsInterface(JacksonMessageSerializer.class, MessageSerializer.class));
+    }
+
+    private boolean implementsInterface(Class<?> typeUnderTest, Class<?> interfaceType) {
+        return containsType(typeUnderTest.getInterfaces(), interfaceType);
+    }
+
+    private boolean containsType(Class<?>[] source, Class<?> type) {
+        for (Class<?> t : source) {
+            if (t.equals(type)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Test
+    public void sut_serializes_immutable_message_having_json_creator_correctly() {
+        // Arrange
+        ImmutableMessageWithJsonCreator message = new ImmutableMessageWithJsonCreator(1024, "foo");
+        JacksonMessageSerializer sut = new JacksonMessageSerializer();
+
+        // Act
+        String value = sut.serialize(message);
+        System.out.println("The serialized value is '" + value + "'.");
+        Object actual = sut.deserialize(value);
+
+        // Assert
+        Assert.assertNotNull("The actual value is null.", actual);
+        Assert.assertTrue(
+                "The actual value is not an instance of ImmutableMessageWithJsonCreator.",
+                actual instanceof ImmutableMessageWithJsonCreator);
+        ImmutableMessageWithJsonCreator actualMessage = (ImmutableMessageWithJsonCreator)actual;
+        Assert.assertEquals(message.getIntProperty(), actualMessage.getIntProperty());
+        Assert.assertEquals(message.getStringProperty(), actualMessage.getStringProperty());
+    }
+
+    @Test
+    public void serialize_has_guard_clause_for_null_message() {
+        // Arrange
+        JacksonMessageSerializer sut = new JacksonMessageSerializer();
+
+        // Act
+        IllegalArgumentException expected = null;
+        try {
+            sut.serialize(null);
+        } catch (IllegalArgumentException e) {
+            expected = e;
+        }
+
+        // Assert
+        Assert.assertNotNull(
+                "serialize() did not throw IllegalArgumentException.",
+                expected != null);
+        assert expected != null;
+        Assert.assertTrue(
+                "The error message should contain the name of the parameter 'message'.",
+                expected.getMessage().contains("'message'"));
+    }
+
+    @Test
+    public void deserialize_has_guard_clause_for_null_value() {
+        // Arrange
+        JacksonMessageSerializer sut = new JacksonMessageSerializer();
+
+        // Act
+        IllegalArgumentException expected = null;
+        try {
+            sut.deserialize(null);
+        } catch (IllegalArgumentException e) {
+            expected = e;
+        }
+
+        // Assert
+        Assert.assertTrue(
+                "deserialize() did not throw IllegalArgumentException.",
+                expected != null);
+        Assert.assertTrue(
+                "The error message should contain the name of the parameter 'value'.",
+                expected.getMessage().contains("'value'"));
+    }
+
+    @Test
+    public void sut_serializes_mutable_message_not_having_json_creator_correctly() {
+        // Arrange
+        JacksonMessageSerializer sut = new JacksonMessageSerializer();
+        MutableMessageWithoutJsonCreator message = new MutableMessageWithoutJsonCreator();
+        message.setIntProperty(1024);
+        message.setStringProperty("foo");
+
+        // Act
+        String value = sut.serialize(message);
+        System.out.println("The serialized value is '" + value + "'.");
+        Object actual = sut.deserialize(value);
+
+        // Assert
+        Assert.assertNotNull("The actual value is null.", actual);
+        Assert.assertTrue(
+                "The actual value is not an instance of ImmutableMessageWithJsonCreator.",
+                actual instanceof MutableMessageWithoutJsonCreator);
+        MutableMessageWithoutJsonCreator actualMessage = (MutableMessageWithoutJsonCreator)actual;
+        Assert.assertEquals(message.getIntProperty(), actualMessage.getIntProperty());
+        Assert.assertEquals(message.getStringProperty(), actualMessage.getStringProperty());
+    }
+
+    @Test
+    public void serialize_throws_RuntimeException_for_JsonProcessingException() {
+        // Arrange
+        EmptyObject invalidMessage = new EmptyObject();
+        JacksonMessageSerializer sut = new JacksonMessageSerializer();
+
+        // Act
+        RuntimeException expected = null;
+        try {
+            sut.serialize(invalidMessage);
+        } catch (RuntimeException e) {
+            expected = e;
+        }
+
+        // Assert
+        Assert.assertTrue(
+                "serialize() did not throw RuntimeException.",
+                expected != null);
+        Assert.assertTrue(
+                "The cause was not set correctly.",
+                expected.getCause() instanceof JsonProcessingException);
+    }
+
+    @Test
+    public void deserialize_throws_RuntimeException_for_invalid_json() {
+        // Arrange
+        String value = "This is not a valid json document.";
+        JacksonMessageSerializer sut = new JacksonMessageSerializer();
+
+        // Act
+        RuntimeException expected = null;
+        try {
+            sut.deserialize(value);
+        } catch (RuntimeException e) {
+            expected = e;
+        }
+
+        // Assert
+        Assert.assertTrue(
+                "deserialize() did not throw RuntimeException.",
+                expected != null);
+        Assert.assertTrue(
+                "The cause was not set correctly.",
+                expected.getCause() instanceof IOException);
+    }
+
+    @Test
+    public void sut_serializes_final_immutable_message_having_json_creator_correctly() {
+        // Arrange
+        FinalImmutableMessageWithJsonCreator message = new FinalImmutableMessageWithJsonCreator(1024, "foo");
+        JacksonMessageSerializer sut = new JacksonMessageSerializer();
+
+        // Act
+        String value = sut.serialize(message);
+        System.out.println("The serialized value is '" + value + "'.");
+        Object actual = sut.deserialize(value);
+
+        // Assert
+        Assert.assertNotNull("The actual value is null.", actual);
+        Assert.assertTrue(
+                "The actual value is not an instance of FinalImmutableMessageWithJsonCreator.",
+                actual instanceof FinalImmutableMessageWithJsonCreator);
+        FinalImmutableMessageWithJsonCreator actualMessage = (FinalImmutableMessageWithJsonCreator)actual;
+        Assert.assertEquals(message.getIntProperty(), actualMessage.getIntProperty());
+        Assert.assertEquals(message.getStringProperty(), actualMessage.getStringProperty());
+    }
+}

--- a/src/test/java/io/loom/core/messaging/JacksonMessageSerializerSpecs.java
+++ b/src/test/java/io/loom/core/messaging/JacksonMessageSerializerSpecs.java
@@ -1,10 +1,9 @@
 package io.loom.core.messaging;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.IOException;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.io.IOException;
 
 public class JacksonMessageSerializerSpecs {
     @Test
@@ -165,7 +164,8 @@ public class JacksonMessageSerializerSpecs {
     @Test
     public void sut_serializes_final_immutable_message_having_json_creator_correctly() {
         // Arrange
-        FinalImmutableMessageWithJsonCreator message = new FinalImmutableMessageWithJsonCreator(1024, "foo");
+        FinalImmutableMessageWithJsonCreator message =
+                new FinalImmutableMessageWithJsonCreator(1024, "foo");
         JacksonMessageSerializer sut = new JacksonMessageSerializer();
 
         // Act
@@ -178,7 +178,8 @@ public class JacksonMessageSerializerSpecs {
         Assert.assertTrue(
                 "The actual value is not an instance of FinalImmutableMessageWithJsonCreator.",
                 actual instanceof FinalImmutableMessageWithJsonCreator);
-        FinalImmutableMessageWithJsonCreator actualMessage = (FinalImmutableMessageWithJsonCreator)actual;
+        FinalImmutableMessageWithJsonCreator actualMessage =
+                (FinalImmutableMessageWithJsonCreator)actual;
         Assert.assertEquals(message.getIntProperty(), actualMessage.getIntProperty());
         Assert.assertEquals(message.getStringProperty(), actualMessage.getStringProperty());
     }

--- a/src/test/java/io/loom/core/messaging/MutableMessageWithoutJsonCreator.java
+++ b/src/test/java/io/loom/core/messaging/MutableMessageWithoutJsonCreator.java
@@ -1,0 +1,22 @@
+package io.loom.core.messaging;
+
+class MutableMessageWithoutJsonCreator {
+    private int intField;
+    private String stringField;
+
+    public int getIntProperty() {
+        return intField;
+    }
+
+    public void setIntProperty(int intValue) {
+        this.intField = intValue;
+    }
+
+    public String getStringProperty() {
+        return stringField;
+    }
+
+    public void setStringProperty(String stringValue) {
+        this.stringField = stringValue;
+    }
+}


### PR DESCRIPTION
PR의 주 내용은 다음과 같습니다.
- `MessageSerializer` 인터페이스를 추가합니다.
- `com.fasterxml.jackson` 패키지를 설치합니다.
- `JacksonMessageSerializer` 클래스를 추가합니다.


`JacksonMessageSerializer` 클래스에 구현된 내용은 다음과 같습니다.

- sut_implements_MessageSerializer
- serialize_has_guard_clause_for_null_message
- deserialize_has_guard_clause_for_null_value
- serialize_throws_RuntimeException_for_JsonProcessingException
- deserialize_throws_RuntimeException_for_invalid_json
- sut_serializes_immutable_message_having_json_creator_correctly
- sut_serializes_mutable_message_not_having_json_creator_correctly
- sut_serializes_final_immutable_message_having_json_creator_correctly

이 PR을 통해 `JacksonMessageSerializer` 클래스의 모든 기능이 구현되는 것은 아닙니다. 우선 가장 기본적인 기능을 작성한 후 추가 작업을 통해 부족한 기능 및 테스트 케이스를 보완하려 합니다.