### PR TITLE
JacksonMessageSerializer.serialize() 메서드에 기본 형식 래퍼에 대한 방어구문을 추가합니다.

### DIFF
--- a/src/main/java/io/loom/core/messaging/JacksonMessageSerializer.java
+++ b/src/main/java/io/loom/core/messaging/JacksonMessageSerializer.java
@@ -39,21 +39,29 @@ public class JacksonMessageSerializer implements MessageSerializer {
 
         Class<?> type = message.getClass();
         if (type.equals(Boolean.class)) {
-            throw new IllegalArgumentException("The parameter 'message' cannot be of java.lang.Boolean.");
+            String errorMessage = "The parameter 'message' cannot be of java.lang.Boolean.";
+            throw new IllegalArgumentException(errorMessage);
         } else if (type.equals(Byte.class)) {
-            throw new IllegalArgumentException("The parameter 'message' cannot be of java.lang.Byte.");
+            String errorMessage = "The parameter 'message' cannot be of java.lang.Byte.";
+            throw new IllegalArgumentException(errorMessage);
         } else if (type.equals(Character.class)) {
-            throw new IllegalArgumentException("The parameter 'message' cannot be of java.lang.Character.");
+            String errorMessage = "The parameter 'message' cannot be of java.lang.Character.";
+            throw new IllegalArgumentException(errorMessage);
         } else if (type.equals(Float.class)) {
-            throw new IllegalArgumentException("The parameter 'message' cannot be of java.lang.Float.");
+            String errorMessage = "The parameter 'message' cannot be of java.lang.Float.";
+            throw new IllegalArgumentException(errorMessage);
         } else if (type.equals(Integer.class)) {
-            throw new IllegalArgumentException("The parameter 'message' cannot be of java.lang.Integer.");
+            String errorMessage = "The parameter 'message' cannot be of java.lang.Integer.";
+            throw new IllegalArgumentException(errorMessage);
         } else if (type.equals(Long.class)) {
-            throw new IllegalArgumentException("The parameter 'message' cannot be of java.lang.Long.");
+            String errorMessage = "The parameter 'message' cannot be of java.lang.Long.";
+            throw new IllegalArgumentException(errorMessage);
         } else if (type.equals(Short.class)) {
-            throw new IllegalArgumentException("The parameter 'message' cannot be of java.lang.Short.");
+            String errorMessage = "The parameter 'message' cannot be of java.lang.Short.";
+            throw new IllegalArgumentException(errorMessage);
         } else if (type.equals(Double.class)) {
-            throw new IllegalArgumentException("The parameter 'message' cannot be of java.lang.Double.");
+            String errorMessage = "The parameter 'message' cannot be of java.lang.Double.";
+            throw new IllegalArgumentException(errorMessage);
         }
 
         try {

--- a/src/main/java/io/loom/core/messaging/JacksonMessageSerializer.java
+++ b/src/main/java/io/loom/core/messaging/JacksonMessageSerializer.java
@@ -37,6 +37,25 @@ public class JacksonMessageSerializer implements MessageSerializer {
             throw new IllegalArgumentException("The parameter 'message' cannot be null.");
         }
 
+        Class<?> type = message.getClass();
+        if (type.equals(Boolean.class)) {
+            throw new IllegalArgumentException("The parameter 'message' cannot be of java.lang.Boolean.");
+        } else if (type.equals(Byte.class)) {
+            throw new IllegalArgumentException("The parameter 'message' cannot be of java.lang.Byte.");
+        } else if (type.equals(Character.class)) {
+            throw new IllegalArgumentException("The parameter 'message' cannot be of java.lang.Character.");
+        } else if (type.equals(Float.class)) {
+            throw new IllegalArgumentException("The parameter 'message' cannot be of java.lang.Float.");
+        } else if (type.equals(Integer.class)) {
+            throw new IllegalArgumentException("The parameter 'message' cannot be of java.lang.Integer.");
+        } else if (type.equals(Long.class)) {
+            throw new IllegalArgumentException("The parameter 'message' cannot be of java.lang.Long.");
+        } else if (type.equals(Short.class)) {
+            throw new IllegalArgumentException("The parameter 'message' cannot be of java.lang.Short.");
+        } else if (type.equals(Double.class)) {
+            throw new IllegalArgumentException("The parameter 'message' cannot be of java.lang.Double.");
+        }
+
         try {
             return mapper.writeValueAsString(message);
         } catch (JsonProcessingException e) {

--- a/src/test/java/io/loom/core/messaging/JacksonMessageSerializerSpecs.java
+++ b/src/test/java/io/loom/core/messaging/JacksonMessageSerializerSpecs.java
@@ -211,4 +211,188 @@ public class JacksonMessageSerializerSpecs {
                 message.getComplexProperty().getStringProperty(),
                 actualMessage.getComplexProperty().getStringProperty());
     }
+
+    @Test
+    public void serialize_has_guard_clause_for_Boolean_message() {
+        // Arrange
+        Object message = new Boolean(true);
+        JacksonMessageSerializer sut = new JacksonMessageSerializer();
+
+        // Act
+        IllegalArgumentException expected = null;
+        try {
+            sut.serialize(message);
+        } catch (IllegalArgumentException e) {
+            expected = e;
+        }
+
+        // Assert
+        Assert.assertTrue(
+                "serialize() did not throw IllegalArgumentException.",
+                expected != null);
+        Assert.assertTrue(
+                "The error message should contain the name of the parameter 'message'.",
+                expected.getMessage().contains("'message'"));
+    }
+
+    @Test
+    public void serialize_has_guard_clause_for_Byte_message() {
+        // Arrange
+        Object message = new Byte((byte)16);
+        JacksonMessageSerializer sut = new JacksonMessageSerializer();
+
+        // Act
+        IllegalArgumentException expected = null;
+        try {
+            sut.serialize(message);
+        } catch (IllegalArgumentException e) {
+            expected = e;
+        }
+
+        // Assert
+        Assert.assertTrue(
+                "serialize() did not throw IllegalArgumentException.",
+                expected != null);
+        Assert.assertTrue(
+                "The error message should contain the name of the parameter 'message'.",
+                expected.getMessage().contains("'message'"));
+    }
+
+    @Test
+    public void serialize_has_guard_clause_for_Character_message() {
+        // Arrange
+        Object message = new Character('f');
+        JacksonMessageSerializer sut = new JacksonMessageSerializer();
+
+        // Act
+        IllegalArgumentException expected = null;
+        try {
+            sut.serialize(message);
+        } catch (IllegalArgumentException e) {
+            expected = e;
+        }
+
+        // Assert
+        Assert.assertTrue(
+                "serialize() did not throw IllegalArgumentException.",
+                expected != null);
+        Assert.assertTrue(
+                "The error message should contain the name of the parameter 'message'.",
+                expected.getMessage().contains("'message'"));
+    }
+
+    @Test
+    public void serialize_has_guard_clause_for_Float_message() {
+        // Arrange
+        Object message = new Float(1024);
+        JacksonMessageSerializer sut = new JacksonMessageSerializer();
+
+        // Act
+        IllegalArgumentException expected = null;
+        try {
+            sut.serialize(message);
+        } catch (IllegalArgumentException e) {
+            expected = e;
+        }
+
+        // Assert
+        Assert.assertTrue(
+                "serialize() did not throw IllegalArgumentException.",
+                expected != null);
+        Assert.assertTrue(
+                "The error message should contain the name of the parameter 'message'.",
+                expected.getMessage().contains("'message'"));
+    }
+
+    @Test
+    public void serialize_has_guard_clause_for_Integer_message() {
+        // Arrange
+        Object message = new Integer(1024);
+        JacksonMessageSerializer sut = new JacksonMessageSerializer();
+
+        // Act
+        IllegalArgumentException expected = null;
+        try {
+            sut.serialize(message);
+        } catch (IllegalArgumentException e) {
+            expected = e;
+        }
+
+        // Assert
+        Assert.assertTrue(
+                "serialize() did not throw IllegalArgumentException.",
+                expected != null);
+        Assert.assertTrue(
+                "The error message should contain the name of the parameter 'message'.",
+                expected.getMessage().contains("'message'"));
+    }
+
+    @Test
+    public void serialize_has_guard_clause_for_Long_message() {
+        // Arrange
+        Object message = new Long(1024);
+        JacksonMessageSerializer sut = new JacksonMessageSerializer();
+
+        // Act
+        IllegalArgumentException expected = null;
+        try {
+            sut.serialize(message);
+        } catch (IllegalArgumentException e) {
+            expected = e;
+        }
+
+        // Assert
+        Assert.assertTrue(
+                "serialize() did not throw IllegalArgumentException.",
+                expected != null);
+        Assert.assertTrue(
+                "The error message should contain the name of the parameter 'message'.",
+                expected.getMessage().contains("'message'"));
+    }
+
+    @Test
+    public void serialize_has_guard_clause_for_Short_message() {
+        // Arrange
+        Object message = new Short((short)1024);
+        JacksonMessageSerializer sut = new JacksonMessageSerializer();
+
+        // Act
+        IllegalArgumentException expected = null;
+        try {
+            sut.serialize(message);
+        } catch (IllegalArgumentException e) {
+            expected = e;
+        }
+
+        // Assert
+        Assert.assertTrue(
+                "serialize() did not throw IllegalArgumentException.",
+                expected != null);
+        Assert.assertTrue(
+                "The error message should contain the name of the parameter 'message'.",
+                expected.getMessage().contains("'message'"));
+    }
+
+    @Test
+    public void serialize_has_guard_clause_for_Double_message() {
+        // Arrange
+        Object message = new Double(1024);
+        JacksonMessageSerializer sut = new JacksonMessageSerializer();
+
+        // Act
+        IllegalArgumentException expected = null;
+        try {
+            sut.serialize(message);
+        } catch (IllegalArgumentException e) {
+            expected = e;
+        }
+
+        // Assert
+        Assert.assertTrue(
+                "serialize() did not throw IllegalArgumentException.",
+                expected != null);
+        Assert.assertTrue(
+                "The error message should contain the name of the parameter 'message'.",
+                expected.getMessage().contains("'message'"));
+    }
 }


### PR DESCRIPTION
JacksonMessageSerializer.serialize() 메서드에 다음 형식에 대한 방어구문을 추가합니다.
- `java.lang.Boolean`
- `java.lang.Byte`
- `java.lang.Character`
- `java.lang.Float`
- `java.lang.Integer`
- `java.lang.Long`
- `java.lang.Short`
- `java.lang.Double`