### PR TITLE
JacksonMessageSerializer가 ZonedDateTime 형식의 속성을 직렬화합니다.

### DIFF
--- a/src/main/java/io/loom/core/messaging/JacksonMessageSerializer.java
+++ b/src/main/java/io/loom/core/messaging/JacksonMessageSerializer.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
@@ -32,6 +33,7 @@ public class JacksonMessageSerializer implements MessageSerializer {
         typer = typer.typeProperty("$type");
         mapper = new ObjectMapper()
                 .registerModule(new JavaTimeModule())
+                .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
                 .setDefaultTyping(typer);
     }
 

--- a/src/main/java/io/loom/core/messaging/JacksonMessageSerializer.java
+++ b/src/main/java/io/loom/core/messaging/JacksonMessageSerializer.java
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import java.io.IOException;
+import java.time.ZonedDateTime;
 
 public class JacksonMessageSerializer implements MessageSerializer {
     private class InternalTypeResolverBuilder extends ObjectMapper.DefaultTypeResolverBuilder {
@@ -17,7 +19,7 @@ public class JacksonMessageSerializer implements MessageSerializer {
 
         @Override
         public boolean useForType(JavaType t) {
-            return !t.isPrimitive();
+            return !t.isPrimitive() && t.getRawClass() != ZonedDateTime.class;
         }
     }
 
@@ -28,7 +30,9 @@ public class JacksonMessageSerializer implements MessageSerializer {
         typer = typer.init(JsonTypeInfo.Id.CLASS, null);
         typer = typer.inclusion(JsonTypeInfo.As.PROPERTY);
         typer = typer.typeProperty("$type");
-        mapper = new ObjectMapper().setDefaultTyping(typer);
+        mapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .setDefaultTyping(typer);
     }
 
     @Override

--- a/src/test/java/io/loom/core/messaging/JacksonMessageSerializerSpecs.java
+++ b/src/test/java/io/loom/core/messaging/JacksonMessageSerializerSpecs.java
@@ -2,7 +2,9 @@ package io.loom.core.messaging;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
+import java.time.Clock;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Random;
 
 import org.junit.Assert;
@@ -404,7 +406,7 @@ public class JacksonMessageSerializerSpecs {
         // Arrange
         Random random = new Random();
         MessageWithZonedDateTimeProperty message = new MessageWithZonedDateTimeProperty(
-                ZonedDateTime.now().plusNanos(random.nextInt()));
+                ZonedDateTime.now(Clock.systemUTC()).plusNanos(random.nextInt()));
         JacksonMessageSerializer sut = new JacksonMessageSerializer();
 
         // Act
@@ -418,6 +420,24 @@ public class JacksonMessageSerializerSpecs {
                 "The actual value is not an instance of MessageWithZonedDateTimeProperty.",
                 actual instanceof MessageWithZonedDateTimeProperty);
         MessageWithZonedDateTimeProperty actualMessage = (MessageWithZonedDateTimeProperty)actual;
-        Assert.assertEquals(message.getDateTime().toEpochSecond(), actualMessage.getDateTime().toEpochSecond());
+        Assert.assertEquals(
+                message.getDateTime().toEpochSecond(),
+                actualMessage.getDateTime().toEpochSecond());
+    }
+
+    @Test
+    public void sut_serializes_ZonedDateTime_as_iso_8601() {
+        // Arrange
+        ZonedDateTime dateTime = ZonedDateTime.now(Clock.systemUTC());
+        MessageWithZonedDateTimeProperty message = new MessageWithZonedDateTimeProperty(dateTime);
+        JacksonMessageSerializer sut = new JacksonMessageSerializer();
+
+        // Act
+        String actual = sut.serialize(message);
+        System.out.println("The serialized value is '" + actual + "'.");
+
+        // Assert
+        String formatted = dateTime.format(DateTimeFormatter.ISO_DATE_TIME);
+        Assert.assertTrue(actual.contains("\"dateTime\":\"" + formatted + "\""));
     }
 }

--- a/src/test/java/io/loom/core/messaging/JacksonMessageSerializerSpecs.java
+++ b/src/test/java/io/loom/core/messaging/JacksonMessageSerializerSpecs.java
@@ -2,6 +2,9 @@ package io.loom.core.messaging;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.util.Random;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -394,5 +397,27 @@ public class JacksonMessageSerializerSpecs {
         Assert.assertTrue(
                 "The error message should contain the name of the parameter 'message'.",
                 expected.getMessage().contains("'message'"));
+    }
+
+    @Test
+    public void sut_serializes_properties_of_ZonedDateTime_correctly() {
+        // Arrange
+        Random random = new Random();
+        MessageWithZonedDateTimeProperty message = new MessageWithZonedDateTimeProperty(
+                ZonedDateTime.now().plusNanos(random.nextInt()));
+        JacksonMessageSerializer sut = new JacksonMessageSerializer();
+
+        // Act
+        String value = sut.serialize(message);
+        System.out.println("The serialized value is '" + value + "'.");
+        Object actual = sut.deserialize(value);
+
+        // Assert
+        Assert.assertNotNull("The actual value is null.", actual);
+        Assert.assertTrue(
+                "The actual value is not an instance of MessageWithZonedDateTimeProperty.",
+                actual instanceof MessageWithZonedDateTimeProperty);
+        MessageWithZonedDateTimeProperty actualMessage = (MessageWithZonedDateTimeProperty)actual;
+        Assert.assertEquals(message.getDateTime().toEpochSecond(), actualMessage.getDateTime().toEpochSecond());
     }
 }

--- a/src/test/java/io/loom/core/messaging/MessageWithZonedDateTimeProperty.java
+++ b/src/test/java/io/loom/core/messaging/MessageWithZonedDateTimeProperty.java
@@ -1,0 +1,19 @@
+package io.loom.core.messaging;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.ZonedDateTime;
+
+public class MessageWithZonedDateTimeProperty {
+    private ZonedDateTime dateTime;
+
+    @JsonCreator
+    public MessageWithZonedDateTimeProperty(@JsonProperty("dateTime") ZonedDateTime dateTime) {
+        this.dateTime = dateTime;
+    }
+
+    public ZonedDateTime getDateTime() {
+        return this.dateTime;
+    }
+}


### PR DESCRIPTION
JacksonMessageSerializer가 ZonedDateTime 형식의 속성을 직렬화합니다. 직렬화 형식은 메시지 가독성을 위해 [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)을 따릅니다.

This resolves #50 