### PR TITLE
DomainEvent 의 raise 메소드명을 setHeaderProperties 로 변경합니다

### DIFF
--- a/src/main/java/io/loom/core/event/AbstractDomainEvent.java
+++ b/src/main/java/io/loom/core/event/AbstractDomainEvent.java
@@ -21,7 +21,7 @@ public abstract class AbstractDomainEvent implements DomainEvent {
     }
 
     @Override
-    public void raise(VersionedEntity versionedEntity) {
+    public void setHeaderProperties(VersionedEntity versionedEntity) {
         UUID aggregateId = versionedEntity.getId();
         long version = versionedEntity.getVersion();
         ZonedDateTime occurrenceTime = ZonedDateTime.now();

--- a/src/main/java/io/loom/core/event/DomainEvent.java
+++ b/src/main/java/io/loom/core/event/DomainEvent.java
@@ -13,5 +13,5 @@ public interface DomainEvent extends Message {
 
     ZonedDateTime getOccurrenceTime();
 
-    void raise(VersionedEntity versionedEntity);
+    void setHeaderProperties(VersionedEntity versionedEntity);
 }

--- a/src/test/java/io/loom/core/event/AbstractDomainEventSpecs.java
+++ b/src/test/java/io/loom/core/event/AbstractDomainEventSpecs.java
@@ -100,7 +100,7 @@ public class AbstractDomainEventSpecs {
     }
 
     @Test
-    public void raise_has_guard_clause_for_null_aggregateId() {
+    public void setHeaderProperties_has_guard_clause_for_null_aggregateId() {
         // Arrange
         VersionedEntity versionedEntity = Mockito.mock(VersionedEntity.class);
         Mockito.when(versionedEntity.getId()).thenReturn(null);
@@ -111,7 +111,7 @@ public class AbstractDomainEventSpecs {
         // Act
         IllegalArgumentException expected = null;
         try {
-            sut.raise(versionedEntity);
+            sut.setHeaderProperties(versionedEntity);
         } catch (IllegalArgumentException e) {
             expected = e;
         }
@@ -124,7 +124,7 @@ public class AbstractDomainEventSpecs {
     }
 
     @Test
-    public void raise_has_guard_clause_for_minimum_value_of_version() {
+    public void setHeaderProperties_has_guard_clause_for_minimum_value_of_version() {
         // Arrange
         VersionedEntity versionedEntity = Mockito.mock(VersionedEntity.class);
         Mockito.when(versionedEntity.getId()).thenReturn(UUID.randomUUID());
@@ -135,7 +135,7 @@ public class AbstractDomainEventSpecs {
         // Act
         IllegalArgumentException expected = null;
         try {
-            sut.raise(versionedEntity);
+            sut.setHeaderProperties(versionedEntity);
         } catch (IllegalArgumentException e) {
             expected = e;
         }
@@ -148,7 +148,7 @@ public class AbstractDomainEventSpecs {
     }
 
     @Test
-    public void raise_sets_header_properties_correctly() {
+    public void setHeaderProperties_sets_header_properties_correctly() {
         // Arrange
         UUID aggregateId = UUID.randomUUID();
         Random random = new Random();
@@ -160,7 +160,7 @@ public class AbstractDomainEventSpecs {
         IssueCreatedForTesting sut = new IssueCreatedForTesting();
 
         // Act
-        sut.raise(versionedEntity);
+        sut.setHeaderProperties(versionedEntity);
 
         // Assert
         Assert.assertEquals(aggregateId, sut.getAggregateId());


### PR DESCRIPTION
DomainEvent 에서 raise 메소드에 VersionedEntity 를 넘깁니다.

이때 Event 객체의 header properties(aggregateId, version, occurrenceTime) 을 셋팅해주는 역할을 하고 있습니다. 그런데 `raise` 라는 이름이 실행했을때 넘어온 Entity 에 raise 될거로 기대됩니다.

동작에 적절한 이름으로 변경하고자 합니다.  (setHeaderProperties)

관련하여 다른 의견이 있으시거나, 좀 더 적절한 메소드명이 있으면 추천해주시면 좋을거 같습니다.
