### PR TITLE
DomainEvent 에 canSetHeaderProperties 를 추가합니다.

### DIFF
--- a/src/main/java/io/loom/core/event/AbstractDomainEvent.java
+++ b/src/main/java/io/loom/core/event/AbstractDomainEvent.java
@@ -22,6 +22,10 @@ public abstract class AbstractDomainEvent implements DomainEvent {
 
     @Override
     public void setHeaderProperties(VersionedEntity versionedEntity) {
+        if (!this.canSetHeaderProperties()) {
+            throw new IllegalStateException(
+                    "The state of this instance can not be set to a header properties.");
+        }
         UUID aggregateId = versionedEntity.getId();
         long version = versionedEntity.getVersion();
         ZonedDateTime occurrenceTime = ZonedDateTime.now();

--- a/src/main/java/io/loom/core/event/AbstractDomainEvent.java
+++ b/src/main/java/io/loom/core/event/AbstractDomainEvent.java
@@ -32,6 +32,13 @@ public abstract class AbstractDomainEvent implements DomainEvent {
     }
 
     @Override
+    public boolean canSetHeaderProperties() {
+        return this.aggregateId == null
+                && this.version == 0
+                && this.occurrenceTime == null;
+    }
+
+    @Override
     public final UUID getAggregateId() {
         return this.aggregateId;
     }

--- a/src/main/java/io/loom/core/event/DomainEvent.java
+++ b/src/main/java/io/loom/core/event/DomainEvent.java
@@ -14,4 +14,6 @@ public interface DomainEvent extends Message {
     ZonedDateTime getOccurrenceTime();
 
     void setHeaderProperties(VersionedEntity versionedEntity);
+
+    boolean canSetHeaderProperties();
 }

--- a/src/test/java/io/loom/core/event/AbstractDomainEventSpecs.java
+++ b/src/test/java/io/loom/core/event/AbstractDomainEventSpecs.java
@@ -171,4 +171,46 @@ public class AbstractDomainEventSpecs {
         Assert.assertTrue(after >= occurrenceTime);
         Assert.assertTrue(before <= occurrenceTime);
     }
+
+    @Test
+    public void canSetHeaderProperties_returns_true_constructor_no_args() {
+        // Arrange
+        IssueCreatedForTesting sut = new IssueCreatedForTesting();
+
+        // Act
+        boolean expected = sut.canSetHeaderProperties();
+
+        // Assert
+        Assert.assertTrue(expected);
+    }
+
+    @Test
+    public void canSetHeaderProperties_returns_false_constructor_all_header_properties_args() {
+        // Arrange
+        IssueCreatedForTesting sut = new IssueCreatedForTesting(
+                UUID.randomUUID(), 1L, ZonedDateTime.now());
+
+        // Act
+        boolean expected = sut.canSetHeaderProperties();
+
+        // Assert
+        Assert.assertFalse(expected);
+    }
+
+    @Test
+    public void canSetHeaderProperties_returns_false_after_set_header_properties() {
+        // Arrange
+        VersionedEntity versionedEntity = Mockito.mock(VersionedEntity.class);
+        Mockito.when(versionedEntity.getId()).thenReturn(UUID.randomUUID());
+        Mockito.when(versionedEntity.getVersion())
+                .thenReturn(new Random().nextInt(Integer.MAX_VALUE) + 1L);
+        IssueCreatedForTesting sut = new IssueCreatedForTesting();
+        sut.setHeaderProperties(versionedEntity);
+
+        // Act
+        boolean expected = sut.canSetHeaderProperties();
+
+        // Assert
+        Assert.assertFalse(expected);
+    }
 }

--- a/src/test/java/io/loom/core/event/AbstractDomainEventSpecs.java
+++ b/src/test/java/io/loom/core/event/AbstractDomainEventSpecs.java
@@ -100,6 +100,27 @@ public class AbstractDomainEventSpecs {
     }
 
     @Test
+    public void setHeaderProperties_canSetHeaderProperties_false() {
+        // Arrange
+        VersionedEntity versionedEntity = Mockito.mock(VersionedEntity.class);
+        IssueCreatedForTesting sut = Mockito.spy(new IssueCreatedForTesting());
+        Mockito.when(sut.canSetHeaderProperties()).thenReturn(false);
+
+        // Act
+        IllegalStateException expected = null;
+        try {
+            sut.setHeaderProperties(versionedEntity);
+        } catch (IllegalStateException e) {
+            expected = e;
+        }
+
+        // Assert
+        Assert.assertNotNull(expected);
+        Assert.assertTrue(expected.getMessage()
+                .equals("The state of this instance can not be set to a header properties."));
+    }
+
+    @Test
     public void setHeaderProperties_has_guard_clause_for_null_aggregateId() {
         // Arrange
         VersionedEntity versionedEntity = Mockito.mock(VersionedEntity.class);


### PR DESCRIPTION
DomainEvent 에 이미 headerProperties 가 설정되어 있는데 다른 VersionedEntity 로 값을 바꾸지 않도록 체크 메소드를 추가합니다.

추가로 `setHeaderProperties` 수행시 해당 체크 메소드로 검사하는 로직을 보완합니다.