### PR TITLE
AbstractAggregateRoot 에 pollAllPendingEvents 를 구현합니다.

### DIFF
--- a/src/main/java/io/loom/core/aggregate/AbstractAggregateRoot.java
+++ b/src/main/java/io/loom/core/aggregate/AbstractAggregateRoot.java
@@ -2,9 +2,16 @@ package io.loom.core.aggregate;
 
 import io.loom.core.event.DomainEvent;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 public abstract class AbstractAggregateRoot implements AggregateRoot {
+    // Test 를 위해 package-public 으로 합니다.
+    // TODO: raise method 가 구현될 때 private 으로 전환 합니다.
+    final List<DomainEvent> pendingEvents = new ArrayList<>();
+
     private final UUID id;
 
     protected AbstractAggregateRoot(UUID id) {
@@ -27,6 +34,13 @@ public abstract class AbstractAggregateRoot implements AggregateRoot {
 
     @Override
     public final Iterable<DomainEvent> pollAllPendingEvents() {
-        return null;
+        if (this.pendingEvents.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<DomainEvent> events = new ArrayList<>(this.pendingEvents);
+        events = Collections.unmodifiableList(events);
+        this.pendingEvents.clear();
+        return events;
     }
 }

--- a/src/test/java/io/loom/core/aggregate/AbstractAggregateRootSpecs.java
+++ b/src/test/java/io/loom/core/aggregate/AbstractAggregateRootSpecs.java
@@ -1,9 +1,16 @@
 package io.loom.core.aggregate;
 
+import io.loom.core.event.DomainEvent;
+
+import java.util.List;
+import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class AbstractAggregateRootSpecs {
     public class IssueForTesting extends AbstractAggregateRoot {
@@ -53,5 +60,71 @@ public class AbstractAggregateRootSpecs {
 
         // Assert
         Assert.assertEquals(0, sut.getVersion());
+    }
+
+    @Test
+    public void pollAllPendingEvents_returns_new_Iterable_instance() {
+        // Arrange
+        IssueForTesting sut = new IssueForTesting(UUID.randomUUID());
+
+        // Act
+        Iterable<DomainEvent> result = sut.pollAllPendingEvents();
+
+        // Assert
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.iterator().hasNext());
+    }
+
+    @Test
+    public void pollAllPendingEvents_returns_all_pending_events() {
+        // Arrange
+        IssueForTesting sut = new IssueForTesting(UUID.randomUUID());
+        int count = new Random().nextInt(100) + 1;
+        List<DomainEvent> events = Stream.iterate(0, i -> i  + 1).limit(count)
+                .map(i -> Mockito.mock(DomainEvent.class))
+                .collect(Collectors.toList());
+        sut.pendingEvents.addAll(events);
+
+        // Act
+        Iterable<DomainEvent> result = sut.pollAllPendingEvents();
+
+        // Assert
+        Assert.assertNotNull(result);
+        Assert.assertEquals(events, result);
+    }
+
+    @Test
+    public void pollAllPendingEvents_clears_pending_event_queue() {
+        // Arrange
+        IssueForTesting sut = new IssueForTesting(UUID.randomUUID());
+        int count = new Random().nextInt(100) + 1;
+        List<DomainEvent> events = Stream.iterate(0, i -> i  + 1).limit(count)
+                .map(i -> Mockito.mock(DomainEvent.class))
+                .collect(Collectors.toList());
+        sut.pendingEvents.addAll(events);
+        sut.pollAllPendingEvents();
+
+        // Act
+        Iterable<DomainEvent> result = sut.pollAllPendingEvents();
+
+        // Assert
+        Assert.assertNotNull(result);
+        Assert.assertFalse(result.iterator().hasNext());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void pollAllPendingEvents_returns_unmodifiable_collection() {
+        // Arrange
+        IssueForTesting sut = new IssueForTesting(UUID.randomUUID());
+        int count = new Random().nextInt(100) + 1;
+        List<DomainEvent> events = Stream.iterate(0, i -> i  + 1).limit(count)
+                .map(i -> Mockito.mock(DomainEvent.class))
+                .collect(Collectors.toList());
+        sut.pendingEvents.addAll(events);
+        List<DomainEvent> result = (List<DomainEvent>) sut.pollAllPendingEvents();
+
+        // Act
+        DomainEvent newEvent = Mockito.mock(DomainEvent.class);
+        result.add(newEvent);
     }
 }


### PR DESCRIPTION
AbstarctAggregateRoot 에 pollAllPendingEvents 를 구현합니다.

* pollAllPendingEvents 를 수행하면 pending 된 event iterable 을 반환합니다.
* 반환된 iterable 은 unmodifiable 합니다.
* AbstractAggregateRoot 의 pendingEvents 는 비웁니다.