### PR TITLE
AbstractDomainEvent 의 setHeaderProperties 를 onRaise 로 리팩터합니다

### DIFF
--- a/src/main/java/io/loom/core/event/DomainEvent.java
+++ b/src/main/java/io/loom/core/event/DomainEvent.java
@@ -13,5 +13,5 @@ public interface DomainEvent extends Message {
 
     ZonedDateTime getOccurrenceTime();
 
-    void setHeaderProperties(VersionedEntity versionedEntity);
+    void onRaise(VersionedEntity versionedEntity);
 }


### PR DESCRIPTION
setHeaderProperties 를 onRaise 로 리팩터합니다.

AbstractDomainEvent 에서 onRaise 메소드는 다음의 역할을 합니다.
- AbstractDomainEvent 의 headerProperties 에 값이 셋팅되어 있지 않다면 셋팅합니다.
- 이미 값이 셋팅되어 있을때 onRaise 에 넘어온 VersionedEntity 의 id/version 이 다르다면 Exception 을 발생시킵니다.
