### PR TITLE
AbstractAggregateRoot.raise() 메서드를 추가합니다.

### DIFF
--- a/src/main/java/io/loom/core/aggregate/AbstractAggregateRoot.java
+++ b/src/main/java/io/loom/core/aggregate/AbstractAggregateRoot.java
@@ -8,11 +8,9 @@ import java.util.List;
 import java.util.UUID;
 
 public abstract class AbstractAggregateRoot implements AggregateRoot {
-    // Test 를 위해 package-public 으로 합니다.
-    // TODO: raise method 가 구현될 때 private 으로 전환 합니다.
-    final List<DomainEvent> pendingEvents = new ArrayList<>();
-
     private final UUID id;
+    private final List<DomainEvent> pendingEvents = new ArrayList<>();
+    private long version;
 
     protected AbstractAggregateRoot(UUID id) {
         if (id == null) {
@@ -20,6 +18,7 @@ public abstract class AbstractAggregateRoot implements AggregateRoot {
         }
 
         this.id = id;
+        this.version = 0;
     }
 
     @Override
@@ -29,7 +28,7 @@ public abstract class AbstractAggregateRoot implements AggregateRoot {
 
     @Override
     public final long getVersion() {
-        return 0;
+        return this.version;
     }
 
     @Override
@@ -42,5 +41,17 @@ public abstract class AbstractAggregateRoot implements AggregateRoot {
         events = Collections.unmodifiableList(events);
         this.pendingEvents.clear();
         return events;
+    }
+
+    protected void raise(DomainEvent domainEvent) {
+        if (domainEvent == null) {
+            throw new IllegalArgumentException("The argument 'domainEvent' cannot be null. ");
+        }
+
+        domainEvent.onRaise(this);
+        this.pendingEvents.add(domainEvent);
+        this.version++;
+
+        // TODO: 이벤트 처리기 실행 논리를 구현합니다.
     }
 }

--- a/src/main/java/io/loom/core/aggregate/AbstractAggregateRoot.java
+++ b/src/main/java/io/loom/core/aggregate/AbstractAggregateRoot.java
@@ -48,10 +48,18 @@ public abstract class AbstractAggregateRoot implements AggregateRoot {
             throw new IllegalArgumentException("The argument 'domainEvent' cannot be null. ");
         }
 
-        domainEvent.onRaise(this);
-        this.pendingEvents.add(domainEvent);
-        this.version++;
+        raiseAndAppend(domainEvent);
+        increaseVersion();
 
         // TODO: 이벤트 처리기 실행 논리를 구현합니다.
+    }
+
+    private void raiseAndAppend(DomainEvent domainEvent) {
+        domainEvent.onRaise(this);
+        this.pendingEvents.add(domainEvent);
+    }
+
+    private void increaseVersion() {
+        this.version++;
     }
 }

--- a/src/main/java/io/loom/core/aggregate/AbstractAggregateRoot.java
+++ b/src/main/java/io/loom/core/aggregate/AbstractAggregateRoot.java
@@ -14,7 +14,7 @@ public abstract class AbstractAggregateRoot implements AggregateRoot {
 
     protected AbstractAggregateRoot(UUID id) {
         if (id == null) {
-            throw new IllegalArgumentException("The parameter 'id' cannot be null.");
+            throw new IllegalArgumentException("The argument 'id' cannot be null.");
         }
 
         this.id = id;

--- a/src/test/java/io/loom/core/aggregate/AbstractAggregateRootSpecs.java
+++ b/src/test/java/io/loom/core/aggregate/AbstractAggregateRootSpecs.java
@@ -4,7 +4,10 @@ import io.loom.core.event.AbstractDomainEvent;
 import io.loom.core.event.DomainEvent;
 
 import java.time.ZonedDateTime;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -133,7 +136,7 @@ public class AbstractAggregateRootSpecs {
         // Arrange
         AggregateRootProxy sut = new AggregateRootProxy(UUID.randomUUID());
         AbstractDomainEvent domainEvent = Mockito.spy(AbstractDomainEvent.class);
-        ZonedDateTime lowerBoundOfOccurrenceTime = ZonedDateTime.now();
+        final ZonedDateTime lowerBoundOfOccurrenceTime = ZonedDateTime.now();
 
         // Act
         sut.raise(domainEvent);
@@ -145,7 +148,8 @@ public class AbstractAggregateRootSpecs {
         Assert.assertEquals(domainEvent, actual.get(0));
         Assert.assertEquals(1, actual.get(0).getVersion());
         Assert.assertEquals(sut.getId(), actual.get(0).getAggregateId());
-        Assert.assertTrue(lowerBoundOfOccurrenceTime.compareTo(actual.get(0).getOccurrenceTime()) <= 0);
+        Assert.assertTrue(
+                lowerBoundOfOccurrenceTime.compareTo(actual.get(0).getOccurrenceTime()) <= 0);
         Assert.assertTrue(ZonedDateTime.now().compareTo(actual.get(0).getOccurrenceTime()) >= 0);
     }
 
@@ -162,7 +166,7 @@ public class AbstractAggregateRootSpecs {
         AggregateRootProxy sut = new AggregateRootProxy(UUID.randomUUID());
         sut.raise(Mockito.spy(AbstractDomainEvent.class));
         AbstractDomainEvent domainEvent = Mockito.spy(AbstractDomainEvent.class);
-        ZonedDateTime lowerBoundOfOccurrenceTime = ZonedDateTime.now();
+        final ZonedDateTime lowerBoundOfOccurrenceTime = ZonedDateTime.now();
 
         // Act
         sut.raise(domainEvent);
@@ -174,7 +178,8 @@ public class AbstractAggregateRootSpecs {
         Assert.assertEquals(domainEvent, actual.get(1));
         Assert.assertEquals(2, actual.get(1).getVersion());
         Assert.assertEquals(sut.getId(), actual.get(1).getAggregateId());
-        Assert.assertTrue(lowerBoundOfOccurrenceTime.compareTo(actual.get(1).getOccurrenceTime()) <= 0);
+        Assert.assertTrue(
+                lowerBoundOfOccurrenceTime.compareTo(actual.get(1).getOccurrenceTime()) <= 0);
         Assert.assertTrue(ZonedDateTime.now().compareTo(actual.get(1).getOccurrenceTime()) >= 0);
     }
 
@@ -187,8 +192,7 @@ public class AbstractAggregateRootSpecs {
         // Act
         try {
             sut.raise(null);
-        }
-        catch (Exception exception) {
+        } catch (Exception exception) {
             thrown = exception;
         }
 

--- a/src/test/java/io/loom/core/aggregate/AbstractAggregateRootSpecs.java
+++ b/src/test/java/io/loom/core/aggregate/AbstractAggregateRootSpecs.java
@@ -1,10 +1,10 @@
 package io.loom.core.aggregate;
 
+import io.loom.core.event.AbstractDomainEvent;
 import io.loom.core.event.DomainEvent;
 
-import java.util.List;
-import java.util.Random;
-import java.util.UUID;
+import java.time.ZonedDateTime;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -83,7 +83,7 @@ public class AbstractAggregateRootSpecs {
         List<DomainEvent> events = Stream.iterate(0, i -> i  + 1).limit(count)
                 .map(i -> Mockito.mock(DomainEvent.class))
                 .collect(Collectors.toList());
-        sut.pendingEvents.addAll(events);
+        events.forEach(sut::raise);
 
         // Act
         Iterable<DomainEvent> result = sut.pollAllPendingEvents();
@@ -101,7 +101,7 @@ public class AbstractAggregateRootSpecs {
         List<DomainEvent> events = Stream.iterate(0, i -> i  + 1).limit(count)
                 .map(i -> Mockito.mock(DomainEvent.class))
                 .collect(Collectors.toList());
-        sut.pendingEvents.addAll(events);
+        events.forEach(sut::raise);
         sut.pollAllPendingEvents();
 
         // Act
@@ -120,11 +120,97 @@ public class AbstractAggregateRootSpecs {
         List<DomainEvent> events = Stream.iterate(0, i -> i  + 1).limit(count)
                 .map(i -> Mockito.mock(DomainEvent.class))
                 .collect(Collectors.toList());
-        sut.pendingEvents.addAll(events);
+        events.forEach(sut::raise);
         List<DomainEvent> result = (List<DomainEvent>) sut.pollAllPendingEvents();
 
         // Act
         DomainEvent newEvent = Mockito.mock(DomainEvent.class);
         result.add(newEvent);
+    }
+
+    @Test
+    public void raise_adds_pending_event_correctly() {
+        // Arrange
+        AggregateRootProxy sut = new AggregateRootProxy(UUID.randomUUID());
+        AbstractDomainEvent domainEvent = Mockito.spy(AbstractDomainEvent.class);
+        ZonedDateTime lowerBoundOfOccurrenceTime = ZonedDateTime.now();
+
+        // Act
+        sut.raise(domainEvent);
+
+        // Assert
+        List<DomainEvent> actual = new ArrayList<>();
+        sut.pollAllPendingEvents().forEach(actual::add);
+        Assert.assertEquals(1, actual.size());
+        Assert.assertEquals(domainEvent, actual.get(0));
+        Assert.assertEquals(1, actual.get(0).getVersion());
+        Assert.assertEquals(sut.getId(), actual.get(0).getAggregateId());
+        Assert.assertTrue(lowerBoundOfOccurrenceTime.compareTo(actual.get(0).getOccurrenceTime()) <= 0);
+        Assert.assertTrue(ZonedDateTime.now().compareTo(actual.get(0).getOccurrenceTime()) >= 0);
+    }
+
+    @Test
+    public void raise_increases_version() {
+        AggregateRootProxy sut = new AggregateRootProxy(UUID.randomUUID());
+        sut.raise(Mockito.spy(AbstractDomainEvent.class));
+        Assert.assertEquals(1, sut.getVersion());
+    }
+
+    @Test
+    public void raise_appends_pending_event_correctly() {
+        // Arrange
+        AggregateRootProxy sut = new AggregateRootProxy(UUID.randomUUID());
+        sut.raise(Mockito.spy(AbstractDomainEvent.class));
+        AbstractDomainEvent domainEvent = Mockito.spy(AbstractDomainEvent.class);
+        ZonedDateTime lowerBoundOfOccurrenceTime = ZonedDateTime.now();
+
+        // Act
+        sut.raise(domainEvent);
+
+        // Assert
+        List<DomainEvent> actual = new ArrayList<>();
+        sut.pollAllPendingEvents().forEach(actual::add);
+        Assert.assertEquals(2, actual.size());
+        Assert.assertEquals(domainEvent, actual.get(1));
+        Assert.assertEquals(2, actual.get(1).getVersion());
+        Assert.assertEquals(sut.getId(), actual.get(1).getAggregateId());
+        Assert.assertTrue(lowerBoundOfOccurrenceTime.compareTo(actual.get(1).getOccurrenceTime()) <= 0);
+        Assert.assertTrue(ZonedDateTime.now().compareTo(actual.get(1).getOccurrenceTime()) >= 0);
+    }
+
+    @Test
+    public void raise_has_guard_clause_against_null_domainEvent() {
+        // Arrange
+        AggregateRootProxy sut = new AggregateRootProxy(UUID.randomUUID());
+        Exception thrown = null;
+
+        // Act
+        try {
+            sut.raise(null);
+        }
+        catch (Exception exception) {
+            thrown = exception;
+        }
+
+        // Assert
+        Assert.assertNotNull(thrown);
+        Assert.assertTrue(
+                "The type of exception should be " + IllegalArgumentException.class.getTypeName()
+                        + ", but the actual type is "
+                        + thrown.getClass().getTypeName()
+                        + ".",
+                thrown instanceof IllegalArgumentException);
+        IllegalArgumentException actual = (IllegalArgumentException)thrown;
+        Assert.assertTrue(actual.getMessage().contains("domainEvent"));
+    }
+
+    public class AggregateRootProxy extends AbstractAggregateRoot {
+        public AggregateRootProxy(UUID id) {
+            super(id);
+        }
+
+        public void raise(DomainEvent domainEvent) {
+            super.raise(domainEvent);
+        }
     }
 }


### PR DESCRIPTION
도메인 이벤트를 추가하는 기능을 구현하며 이벤트 처리기와 관련된 논리는 이후 구현됩니다.